### PR TITLE
Quick moderation

### DIFF
--- a/Sources/MessageIndex.php
+++ b/Sources/MessageIndex.php
@@ -564,7 +564,7 @@ function MessageIndex()
 	);
 
 	// Is Quick Moderation active/needed?
-	if (!empty($options['display_quick_mod']) && !empty($context['topics']))
+	if (!empty($context['topics']))
 	{
 		$context['can_markread'] = $context['user']['is_logged'];
 		$context['can_lock'] = allowedTo('lock_any');
@@ -606,14 +606,10 @@ function MessageIndex()
 		}
 
 		// Can we use quick moderation checkboxes?
-		if ($options['display_quick_mod'] == 1)
-			$context['can_quick_mod'] = $context['user']['is_logged'] || $context['can_approve'] || $context['can_remove'] || $context['can_lock'] || $context['can_sticky'] || $context['can_move'] || $context['can_merge'] || $context['can_restore'];
-		// Or the icons?
-		else
-			$context['can_quick_mod'] = $context['can_remove'] || $context['can_lock'] || $context['can_sticky'] || $context['can_move'];
+		$context['can_quick_mod'] = $context['user']['is_logged'] || $context['can_approve'] || $context['can_remove'] || $context['can_lock'] || $context['can_sticky'] || $context['can_move'] || $context['can_merge'] || $context['can_restore'];
 	}
 
-	if (!empty($context['can_quick_mod']) && $options['display_quick_mod'] == 1)
+	if (!empty($context['can_quick_mod']))
 	{
 		$context['qmod_actions'] = array('approve', 'remove', 'lock', 'sticky', 'move', 'merge', 'restore', 'markread');
 		call_integration_hook('integrate_quick_mod_actions');

--- a/Sources/Recent.php
+++ b/Sources/Recent.php
@@ -472,8 +472,6 @@ function UnreadTopics()
 		die;
 	}
 
-	$context['showCheckboxes'] = !empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1;
-
 	$context['showing_all_topics'] = isset($_GET['all']);
 	$context['start'] = (int) $_REQUEST['start'];
 	$context['topics_per_page'] = empty($modSettings['disableCustomPerPage']) && !empty($options['topics_per_page']) ? $options['topics_per_page'] : $modSettings['defaultMaxTopics'];
@@ -1391,12 +1389,11 @@ function UnreadTopics()
 			'markread' => array('text' => !empty($context['no_board_limits']) ? 'mark_as_read' : 'mark_read_short', 'image' => 'markread.png', 'custom' => 'data-confirm="'.  $txt['are_sure_mark_read'] .'"', 'class' => 'you_sure', 'url' => $scripturl . '?action=markasread;sa=' . (!empty($context['no_board_limits']) ? 'all' : 'board' . $context['querystring_board_limits']) . ';' . $context['session_var'] . '=' . $context['session_id']),
 		);
 
-		if ($context['showCheckboxes'])
-			$context['recent_buttons']['markselectread'] = array(
-				'text' => 'quick_mod_markread',
-				'image' => 'markselectedread.png',
-				'url' => 'javascript:document.quickModForm.submit();',
-			);
+		$context['recent_buttons']['markselectread'] = array(
+			'text' => 'quick_mod_markread',
+			'image' => 'markselectedread.png',
+			'url' => 'javascript:document.quickModForm.submit();',
+		);
 
 		if (!empty($context['topics']) && !$context['showing_all_topics'])
 			$context['recent_buttons']['readall'] = array('text' => 'unread_topics_all', 'image' => 'markreadall.png', 'url' => $scripturl . '?action=unread;all' . $context['querystring_board_limits'], 'active' => true);
@@ -1407,12 +1404,11 @@ function UnreadTopics()
 			'markread' => array('text' => 'mark_as_read', 'image' => 'markread.png', 'custom' => 'data-confirm="'. $txt['are_sure_mark_read']  .'"', 'class' => 'you_sure', 'url' => $scripturl . '?action=markasread;sa=unreadreplies;topics=' . $context['topics_to_mark'] . ';' . $context['session_var'] . '=' . $context['session_id']),
 		);
 
-		if ($context['showCheckboxes'])
-			$context['recent_buttons']['markselectread'] = array(
-				'text' => 'quick_mod_markread',
-				'image' => 'markselectedread.png',
-				'url' => 'javascript:document.quickModForm.submit();',
-			);
+		$context['recent_buttons']['markselectread'] = array(
+			'text' => 'quick_mod_markread',
+			'image' => 'markselectedread.png',
+			'url' => 'javascript:document.quickModForm.submit();',
+		);
 	}
 
 	// Allow mods to add additional buttons here

--- a/Sources/Search.php
+++ b/Sources/Search.php
@@ -1631,16 +1631,13 @@ function PlushSearch2()
 		$boards_can = boardsAllowedTo(array('post_reply_own', 'post_reply_any'), true, false);
 
 		// How's about some quick moderation?
-		if (!empty($options['display_quick_mod']))
-		{
-			$boards_can = array_merge($boards_can, boardsAllowedTo(array('lock_any', 'lock_own', 'make_sticky', 'move_any', 'move_own', 'remove_any', 'remove_own', 'merge_any'), true, false));
+		$boards_can = array_merge($boards_can, boardsAllowedTo(array('lock_any', 'lock_own', 'make_sticky', 'move_any', 'move_own', 'remove_any', 'remove_own', 'merge_any'), true, false));
 
-			$context['can_lock'] = in_array(0, $boards_can['lock_any']);
-			$context['can_sticky'] = in_array(0, $boards_can['make_sticky']);
-			$context['can_move'] = in_array(0, $boards_can['move_any']);
-			$context['can_remove'] = in_array(0, $boards_can['remove_any']);
-			$context['can_merge'] = in_array(0, $boards_can['merge_any']);
-		}
+		$context['can_lock'] = in_array(0, $boards_can['lock_any']);
+		$context['can_sticky'] = in_array(0, $boards_can['make_sticky']);
+		$context['can_move'] = in_array(0, $boards_can['move_any']);
+		$context['can_remove'] = in_array(0, $boards_can['remove_any']);
+		$context['can_merge'] = in_array(0, $boards_can['merge_any']);
 
 		// What messages are we using?
 		$msg_list = array_keys($context['topics']);
@@ -1972,29 +1969,26 @@ function prepareSearchContext($reset = false)
 	$body_highlighted = $message['body'];
 	$subject_highlighted = $message['subject'];
 
-	if (!empty($options['display_quick_mod']))
-	{
-		$started = $output['first_post']['member']['id'] == $user_info['id'];
+	$started = $output['first_post']['member']['id'] == $user_info['id'];
 
-		$output['quick_mod'] = array(
-			'lock' => in_array(0, $boards_can['lock_any']) || in_array($output['board']['id'], $boards_can['lock_any']) || ($started && (in_array(0, $boards_can['lock_own']) || in_array($output['board']['id'], $boards_can['lock_own']))),
-			'sticky' => (in_array(0, $boards_can['make_sticky']) || in_array($output['board']['id'], $boards_can['make_sticky'])),
-			'move' => in_array(0, $boards_can['move_any']) || in_array($output['board']['id'], $boards_can['move_any']) || ($started && (in_array(0, $boards_can['move_own']) || in_array($output['board']['id'], $boards_can['move_own']))),
-			'remove' => in_array(0, $boards_can['remove_any']) || in_array($output['board']['id'], $boards_can['remove_any']) || ($started && (in_array(0, $boards_can['remove_own']) || in_array($output['board']['id'], $boards_can['remove_own']))),
-			'restore' => $context['can_restore_perm'] && ($modSettings['recycle_board'] == $output['board']['id']),
-		);
+	$output['quick_mod'] = array(
+		'lock' => in_array(0, $boards_can['lock_any']) || in_array($output['board']['id'], $boards_can['lock_any']) || ($started && (in_array(0, $boards_can['lock_own']) || in_array($output['board']['id'], $boards_can['lock_own']))),
+		'sticky' => (in_array(0, $boards_can['make_sticky']) || in_array($output['board']['id'], $boards_can['make_sticky'])),
+		'move' => in_array(0, $boards_can['move_any']) || in_array($output['board']['id'], $boards_can['move_any']) || ($started && (in_array(0, $boards_can['move_own']) || in_array($output['board']['id'], $boards_can['move_own']))),
+		'remove' => in_array(0, $boards_can['remove_any']) || in_array($output['board']['id'], $boards_can['remove_any']) || ($started && (in_array(0, $boards_can['remove_own']) || in_array($output['board']['id'], $boards_can['remove_own']))),
+		'restore' => $context['can_restore_perm'] && ($modSettings['recycle_board'] == $output['board']['id']),
+	);
 
-		$context['can_lock'] |= $output['quick_mod']['lock'];
-		$context['can_sticky'] |= $output['quick_mod']['sticky'];
-		$context['can_move'] |= $output['quick_mod']['move'];
-		$context['can_remove'] |= $output['quick_mod']['remove'];
-		$context['can_merge'] |= in_array($output['board']['id'], $boards_can['merge_any']);
-		$context['can_restore'] |= $output['quick_mod']['restore'];
-		$context['can_markread'] = $context['user']['is_logged'];
+	$context['can_lock'] |= $output['quick_mod']['lock'];
+	$context['can_sticky'] |= $output['quick_mod']['sticky'];
+	$context['can_move'] |= $output['quick_mod']['move'];
+	$context['can_remove'] |= $output['quick_mod']['remove'];
+	$context['can_merge'] |= in_array($output['board']['id'], $boards_can['merge_any']);
+	$context['can_restore'] |= $output['quick_mod']['restore'];
+	$context['can_markread'] = $context['user']['is_logged'];
 
-		$context['qmod_actions'] = array('remove', 'lock', 'sticky', 'move', 'merge', 'restore', 'markread');
-		call_integration_hook('integrate_quick_mod_actions_search');
-	}
+	$context['qmod_actions'] = array('remove', 'lock', 'sticky', 'move', 'merge', 'restore', 'markread');
+	call_integration_hook('integrate_quick_mod_actions_search');
 
 	foreach ($context['key_words'] as $query)
 	{

--- a/Themes/default/Display.template.php
+++ b/Themes/default/Display.template.php
@@ -246,7 +246,7 @@ function template_main()
 		echo '
 				<script>';
 
-	if (!empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1 && $context['can_remove_post'])
+	if ($context['can_remove_post'])
 	{
 		echo '
 					var oInTopicModeration = new InTopicModeration({
@@ -829,7 +829,7 @@ function template_single_post($message)
 									</li>';
 
 		// Show a checkbox for quick moderation?
-		if (!empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1 && $message['can_remove'])
+		if ($message['can_remove'])
 			echo '
 									<li style="display: none;" id="in_topic_mod_check_', $message['id'], '"></li>';
 

--- a/Themes/default/MessageIndex.template.php
+++ b/Themes/default/MessageIndex.template.php
@@ -146,7 +146,7 @@ function template_main()
 		}
 
 		// If Quick Moderation is enabled start the form.
-		if (!empty($context['can_quick_mod']) && $options['display_quick_mod'] > 0 && !empty($context['topics']))
+		if (!empty($context['can_quick_mod']) && !empty($context['topics']))
 			echo '
 	<form action="', $scripturl, '?action=quickmod;board=', $context['current_board'], '.', $context['start'], '" method="post" accept-charset="UTF-8" class="clear" name="quickModForm" id="quickModForm">';
 
@@ -178,7 +178,7 @@ function template_main()
 					<div class="lastpost">', $context['topics_headers']['last_post'], '</div>';
 
 			// Show a "select all" box for quick moderation?
-			if (!empty($context['can_quick_mod']) && $options['display_quick_mod'] == 1)
+			if (!empty($context['can_quick_mod']))
 				echo '
 					<div class="moderation"><input type="checkbox" onclick="invertAll(this, this.form, \'topics[]\');" class="input_check"></div>';
 
@@ -261,29 +261,8 @@ function template_main()
 			if (!empty($context['can_quick_mod']))
 			{
 				echo '
-					<div class="moderation">';
-				if ($options['display_quick_mod'] == 1)
-					echo '
-						<input type="checkbox" name="topics[]" value="', $topic['id'], '" class="input_check">';
-				else
-				{
-					// Check permissions on each and show only the ones they are allowed to use.
-					if ($topic['quick_mod']['remove'])
-						echo '<a href="', $scripturl, '?action=quickmod;board=', $context['current_board'], '.', $context['start'], ';actions%5B', $topic['id'], '%5D=remove;', $context['session_var'], '=', $context['session_id'], '" class="you_sure"><span class="generic_icons delete" title="', $txt['remove_topic'], '"></span></a>';
-
-					if ($topic['quick_mod']['lock'])
-						echo '<a href="', $scripturl, '?action=quickmod;board=', $context['current_board'], '.', $context['start'], ';actions%5B', $topic['id'], '%5D=lock;', $context['session_var'], '=', $context['session_id'], '" class="you_sure"><span class="generic_icons lock" title="', $topic['is_locked'] ? $txt['set_unlock'] : $txt['set_lock'], '"></span></a>';
-
-					if ($topic['quick_mod']['lock'] || $topic['quick_mod']['remove'])
-						echo '<br>';
-
-					if ($topic['quick_mod']['sticky'])
-						echo '<a href="', $scripturl, '?action=quickmod;board=', $context['current_board'], '.', $context['start'], ';actions%5B', $topic['id'], '%5D=sticky;', $context['session_var'], '=', $context['session_id'], '" class="you_sure"><span class="generic_icons sticky" title="', $topic['is_sticky'] ? $txt['set_nonsticky'] : $txt['set_sticky'], '"></span></a>';
-
-					if ($topic['quick_mod']['move'])
-						echo '<a href="', $scripturl, '?action=movetopic;current_board=', $context['current_board'], ';board=', $context['current_board'], '.', $context['start'], ';topic=', $topic['id'], '.0"><span class="generic_icons move" title="', $txt['move_topic'], '"></span></a>';
-				}
-				echo '
+					<div class="moderation">
+						<input type="checkbox" name="topics[]" value="', $topic['id'], '" class="input_check">
 					</div>';
 			}
 			echo '
@@ -292,7 +271,7 @@ function template_main()
 		echo '
 			</div>';
 
-		if (!empty($context['can_quick_mod']) && $options['display_quick_mod'] == 1 && !empty($context['topics']))
+		if (!empty($context['can_quick_mod']) && !empty($context['topics']))
 		{
 			echo '
 				<div class="righttext" id="quick_actions">
@@ -321,7 +300,7 @@ function template_main()
 	</div>';
 
 		// Finish off the form - again.
-		if (!empty($context['can_quick_mod']) && $options['display_quick_mod'] > 0 && !empty($context['topics']))
+		if (!empty($context['can_quick_mod']) && !empty($context['topics']))
 			echo '
 	<input type="hidden" name="' . $context['session_var'] . '" value="' . $context['session_id'] . '">
 	</form>';
@@ -343,7 +322,7 @@ function template_main()
 	// Show breadcrumbs at the bottom too.
 	theme_linktree();
 
-	if (!empty($context['can_quick_mod']) && $options['display_quick_mod'] == 1 && !empty($context['topics']) && $context['can_move'])
+	if (!empty($context['can_quick_mod']) && !empty($context['topics']) && $context['can_move'])
 		echo '
 			<script>
 				if (typeof(window.XMLHttpRequest) != "undefined")

--- a/Themes/default/ModerationCenter.template.php
+++ b/Themes/default/ModerationCenter.template.php
@@ -416,8 +416,7 @@ function template_unapproved_posts()
 			', $context['menu_separator'], '
 				<a href="', $scripturl, '?action=moderate;area=postmod;sa=', $context['current_view'], ';start=', $context['start'], ';', $context['session_var'], '=', $context['session_id'], ';delete=', $item['id'], '">', $remove_button, '</a>';
 
-		if (!empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1)
-			echo '
+		echo '
 				<input type="checkbox" name="item[]" value="', $item['id'], '" checked class="input_check"> ';
 
 		echo '
@@ -428,8 +427,7 @@ function template_unapproved_posts()
 	echo '
 		<div class="pagesection">';
 
-	if (!empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1)
-		echo '
+	echo '
 			<div class="floatright">
 				<select name="do" onchange="if (this.value != 0 &amp;&amp; confirm(\'', $txt['mc_unapproved_sure'], '\')) submit();">
 					<option value="0">', $txt['with_selected'], ':</option>

--- a/Themes/default/Recent.template.php
+++ b/Themes/default/Recent.template.php
@@ -83,8 +83,7 @@ function template_unread()
 	echo '
 	<div id="recent" class="main_content">';
 
-	if ($context['showCheckboxes'])
-		echo '
+	echo '
 		<form action="', $scripturl, '?action=quickmod" method="post" accept-charset="UTF-8" name="quickModForm" id="quickModForm" style="margin: 0;">
 			<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '">
 			<input type="hidden" name="qaction" value="markread">
@@ -114,8 +113,7 @@ function template_unread()
 					</div>';
 
 		// Show a "select all" box for quick moderation?
-		if ($context['showCheckboxes'])
-			echo '
+		echo '
 					<div class="moderation">
 						<input type="checkbox" onclick="invertAll(this, this.form, \'topics[]\');" class="input_check">
 					</div>';
@@ -170,13 +168,12 @@ function template_unread()
 							', sprintf($txt['last_post_topic'], '<a href="' . $topic['last_post']['href'] . '">' . $topic['last_post']['time'] . '</a>', $topic['last_post']['member']['link']), '
 						</div>';
 
-			if ($context['showCheckboxes'])
-				echo '
+			echo '
 						<div class="moderation">
 							<input type="checkbox" name="topics[]" value="', $topic['id'], '" class="input_check">
 						</div>';
 
-				echo '
+			echo '
 					</div>';
 		}
 
@@ -203,8 +200,7 @@ function template_unread()
 				</h3>
 			</div>';
 
-	if ($context['showCheckboxes'])
-		echo '
+	echo '
 		</form>';
 
 	echo '
@@ -224,8 +220,7 @@ function template_replies()
 	echo '
 	<div id="recent">';
 
-	if ($context['showCheckboxes'])
-		echo '
+	echo '
 		<form action="', $scripturl, '?action=quickmod" method="post" accept-charset="UTF-8" name="quickModForm" id="quickModForm" style="margin: 0;">
 			<input type="hidden" name="', $context['session_var'], '" value="', $context['session_id'], '">
 			<input type="hidden" name="qaction" value="markread">
@@ -255,8 +250,7 @@ function template_replies()
 					</div>';
 
 		// Show a "select all" box for quick moderation?
-		if ($context['showCheckboxes'])
-				echo '
+		echo '
 					<div class="moderation">
 						<input type="checkbox" onclick="invertAll(this, this.form, \'topics[]\');" class="input_check">
 					</div>';
@@ -311,8 +305,7 @@ function template_replies()
 								', sprintf($txt['last_post_topic'], '<a href="' . $topic['last_post']['href'] . '">' . $topic['last_post']['time'] . '</a>', $topic['last_post']['member']['link']), '
 							</div>';
 
-			if ($context['showCheckboxes'])
-				echo '
+			echo '
 							<div class="moderation">
 								<input type="checkbox" name="topics[]" value="', $topic['id'], '" class="input_check">
 							</div>';
@@ -337,8 +330,7 @@ function template_replies()
 				</h3>
 			</div>';
 
-	if ($context['showCheckboxes'])
-		echo '
+	echo '
 		</form>';
 
 	echo '

--- a/Themes/default/Search.template.php
+++ b/Themes/default/Search.template.php
@@ -278,19 +278,15 @@ function template_results()
 
 	if ($context['compact'])
 	{
-		// Quick moderation set to checkboxes? Oh, how fun :/.
-		if (!empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1)
-			echo '
+		// Quick moderation.
+		echo '
 	<form action="', $scripturl, '?action=quickmod" method="post" accept-charset="UTF-8" name="topicForm">';
 
 	echo '
 		<div class="cat_bar">
 			<h3 class="catbg">
-				<span class="floatright">';
-					if (!empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1)
-					echo '
-							<input type="checkbox" onclick="invertAll(this, this.form, \'topics[]\');" class="input_check">';
-				echo '
+				<span class="floatright">
+					<input type="checkbox" onclick="invertAll(this, this.form, \'topics[]\');" class="input_check">
 				</span>
 				<span class="generic_icons filter"></span>&nbsp;', $txt['mlist_search_results'], ':&nbsp;', $context['search_params']['search'], '
 			</h3>
@@ -321,44 +317,10 @@ function template_results()
 						<div class="counter">', $message['counter'], '</div>
 						<h5>', $topic['board']['link'], ' / <a href="', $scripturl, '?topic=', $topic['id'], '.msg', $message['id'], '#msg', $message['id'], '">', $message['subject_highlighted'], '</a></h5>
 						<span class="smalltext">&#171;&nbsp;',$txt['by'], '&nbsp;<strong>', $message['member']['link'], '</strong>&nbsp;', $txt['on'], '&nbsp;<em>', $message['time'], '</em>&nbsp;&#187;</span>
+					</div>
+					<div class="floatright">
+						<input type="checkbox" name="topics[]" value="', $topic['id'], '" class="input_check">
 					</div>';
-
-				if (!empty($options['display_quick_mod']))
-				{
-					echo '
-					<div class="floatright">';
-
-					if ($options['display_quick_mod'] == 1)
-					{
-						echo '
-						<input type="checkbox" name="topics[]" value="', $topic['id'], '" class="input_check">';
-					}
-					else
-					{
-						if ($topic['quick_mod']['remove'])
-							echo '
-						<a href="', $scripturl, '?action=quickmod;board=' . $topic['board']['id'] . '.0;actions%5B', $topic['id'], '%5D=remove;', $context['session_var'], '=', $context['session_id'], '" class="you_sure"><span class="generic_icons delete" title="', $txt['remove_topic'], '"></span></a>';
-
-						if ($topic['quick_mod']['lock'])
-							echo '
-						<a href="', $scripturl, '?action=quickmod;board=' . $topic['board']['id'] . '.0;actions%5B', $topic['id'], '%5D=lock;', $context['session_var'], '=', $context['session_id'], '" class="you_sure"><span class="generic_icons lock" title="', $topic['is_locked'] ? $txt['set_unlock'] : $txt['set_lock'], '"></span></a>';
-
-						if ($topic['quick_mod']['lock'] || $topic['quick_mod']['remove'])
-							echo '
-						<br>';
-
-						if ($topic['quick_mod']['sticky'])
-							echo '
-						<a href="', $scripturl, '?action=quickmod;board=' . $topic['board']['id'] . '.0;actions%5B', $topic['id'], '%5D=sticky;', $context['session_var'], '=', $context['session_id'], '" class="you_sure"><span class="generic_icons sticky" title="', $topic['is_sticky'] ? $txt['set_nonsticky'] : $txt['set_sticky'], '"></span></a>';
-
-						if ($topic['quick_mod']['move'])
-							echo '
-						<a href="', $scripturl, '?action=movetopic;topic=', $topic['id'], '.0"><span class="generic_icons move" title="', $txt['move_topic'], '"></span></a>';
-					}
-
-					echo '
-					</div>';
-				}
 
 				if ($message['body_highlighted'] != '')
 					echo '
@@ -377,7 +339,7 @@ function template_results()
 			<span>', $context['page_index'], '</span>
 		</div>';
 
-		if (!empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1 && !empty($context['topics']))
+		if (!empty($context['topics']))
 		{
 			echo '
 			<div style="padding: 4px;">
@@ -405,8 +367,7 @@ function template_results()
 		}
 
 
-		if (!empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1 && !empty($context['topics']))
-			echo '
+		echo '
 			<input type="hidden" name="' . $context['session_var'] . '" value="' . $context['session_id'] . '">
 		</form>';
 
@@ -475,7 +436,7 @@ function template_results()
 		<div class="smalltext righttext" id="search_jump_to">&nbsp;</div>
 		<script>';
 
-	if (!empty($options['display_quick_mod']) && $options['display_quick_mod'] == 1 && !empty($context['topics']) && $context['can_move'])
+	if (!empty($context['topics']) && $context['can_move'])
 		echo '
 				if (typeof(window.XMLHttpRequest) != "undefined")
 					aJumpTo[aJumpTo.length] = new JumpTo({

--- a/Themes/default/Settings.template.php
+++ b/Themes/default/Settings.template.php
@@ -96,17 +96,6 @@ function template_options()
 			'label'  => $txt['drafts_show_saved_enabled'],
 			'default' => true,
 		),
-		$txt['theme_opt_moderation'],
-		array(
-			'id' => 'display_quick_mod',
-			'label' => $txt['display_quick_mod'],
-			'options' => array(
-				0 => $txt['display_quick_mod_none'],
-				1 => $txt['display_quick_mod_check'],
-				2 => $txt['display_quick_mod_image'],
-			),
-			'default' => true,
-		),
 		$txt['theme_opt_personal_messages'],
 		array(
 			'id' => 'popup_messages',

--- a/Themes/default/languages/Profile.english.php
+++ b/Themes/default/languages/Profile.english.php
@@ -339,10 +339,6 @@ $txt['topics_per_page'] = 'Topics to display per page:';
 $txt['messages_per_page'] = 'Messages to display per page:';
 $txt['per_page_default'] = 'forum default';
 $txt['use_editor_quick_reply'] = 'Use full editor in Quick Reply';
-$txt['display_quick_mod'] = 'Show quick-moderation as';
-$txt['display_quick_mod_none'] = 'don\'t show';
-$txt['display_quick_mod_check'] = 'checkboxes';
-$txt['display_quick_mod_image'] = 'icons';
 
 $txt['whois_title'] = 'Look up IP on a regional whois-server';
 $txt['whois_afrinic'] = 'AfriNIC (Africa)';
@@ -563,7 +559,6 @@ $txt['tfa_wait'] = 'Please wait for about 2 minutes before attempting to log in 
 
 $txt['theme_opt_display'] = 'Board and topic display';
 $txt['theme_opt_posting'] = 'Posting';
-$txt['theme_opt_moderation'] = 'Moderation';
 $txt['theme_opt_personal_messages'] = 'Personal Messages';
 
 ?>


### PR DESCRIPTION
This feature is, bizarrely, off by default in the platform which is a nonsense default position to have since quick moderation is a very useful and very cool feature.

However, not only is it off by default, it comes in two different flavours, icons on the lists of topics or checkboxes to multi-select. Might as well streamline all of this to be one true way...