### PR TITLE
Remove HHVM from the build since we legitimately do not care about HH…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,6 @@ php:
   - 7.0
   - 7.1
 
-matrix:
-  include:
-    - php: hhvm
-      dist: trusty
-
 script:
   - sudo add-apt-repository ppa:git-core/ppa -y
   - sudo apt-get update


### PR DESCRIPTION
…VM at this time as a destination target. Most of the benefits we'd see from it are already in PHP 7 anyway.