### PR TITLE
Fix tag nesting on generic lists.

### DIFF
--- a/Themes/default/partials/generic_list.hbs
+++ b/Themes/default/partials/generic_list.hbs
@@ -88,19 +88,17 @@
 {{#if cur_list.additional_rows.bottom_of_list}}
     {{>list_additional_rows cur_list.additional_rows.bottom_of_list}}
 {{/if}}
-		</div>
-{{#if cur_list.form}}
 
-{{/if}}
 {{#if cur_list.form}}
 	{{#each cur_list.form.hidden_fields}}
 		<input type="hidden" name="{{@key}}" value="{{.}}">
 	{{/each}}
 	{{#if cur_list.form.token}}
-		<input type="hidden" name="{{token_var cur_list.form.token}}" value="{{ltoken cur_list.form.token}}">
+		<input type="hidden" name="{{token_var cur_list.form.token}}" value="{{token cur_list.form.token}}">
 	{{/if}}
 	</form>
 {{/if}}
+<div class="clear"></div>
 
 {{#if (and cur_list.list_menu (or (eq cur_list.list_menu.show_on 'top') (eq cur_list.list_menu.show_on 'both')))}}
 	{{> generic_list_links_menu }}


### PR DESCRIPTION
Pushes form data back into the form and ensures some of the list-related forms work correctly and aren't visually misaligned.