### PR TITLE
Take an installer setting and making it not configurable. Fixes #195

### DIFF
--- a/Themes/default/languages/Install.english.php
+++ b/Themes/default/languages/Install.english.php
@@ -102,9 +102,6 @@ $txt['install_settings_compress'] = 'Gzip Output';
 $txt['install_settings_compress_title'] = 'Compress output to save bandwidth.';
 // In this string, you can translate the word "PASS" to change what it says when the test passes.
 $txt['install_settings_compress_info'] = 'This function does not work properly on all servers, but can save you a lot of bandwidth.<br>Click <a href="install.php?obgz=1&amp;pass_string=PASS" onclick="return reqWin(this.href, 200, 60);" target="_blank">here</a> to test it. (it should just say "PASS".)';
-$txt['install_settings_dbsession'] = 'Database Sessions';
-$txt['install_settings_dbsession_title'] = 'Use the database for sessions instead of using files.';
-$txt['install_settings_dbsession_info1'] = 'This feature is almost always for the best, as it makes sessions more dependable.';
 $txt['install_settings_dbsession_info2'] = 'This feature is generally a good idea, but may not work properly on this server.';
 $txt['install_settings_proceed'] = 'Proceed';
 

--- a/other/install.php
+++ b/other/install.php
@@ -909,9 +909,6 @@ function ForumSettings()
 	// Now, to put what we've learned together... and add a path.
 	$incontext['detected_url'] = 'http' . (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on' ? 's' : '') . '://' . $host . substr($_SERVER['PHP_SELF'], 0, strrpos($_SERVER['PHP_SELF'], '/'));
 
-	// Check if the database sessions will even work.
-	$incontext['test_dbsession'] = (ini_get('session.auto_start') != 1);
-
 	$incontext['continue'] = 1;
 
 	// Setup the SSL checkbox...
@@ -1047,7 +1044,7 @@ function DatabasePopulation()
 		'{$boarddir}' => $smcFunc['db_escape_string'](dirname(__FILE__)),
 		'{$boardurl}' => $boardurl,
 		'{$enableCompressedOutput}' => isset($_POST['compress']) ? '1' : '0',
-		'{$databaseSession_enable}' => isset($_POST['dbsession']) ? '1' : '0',
+		'{$databaseSession_enable}' => (ini_get('session.auto_start') != 1) ? '1' : '0',
 		'{$smf_version}' => $GLOBALS['current_smf_version'],
 		'{$current_time}' => time(),
 		'{$sched_task_offset}' => 82800 + mt_rand(0, 86399),
@@ -2201,15 +2198,6 @@ function template_forum_settings()
 					<label for="compress_check">', $txt['install_settings_compress_title'], '</label>
 					<br>
 					<div class="smalltext block">', $txt['install_settings_compress_info'], '</div>
-				</td>
-			</tr>
-			<tr>
-				<td class="textbox" style="vertical-align: top;">', $txt['install_settings_dbsession'], ':</td>
-				<td>
-					<input type="checkbox" name="dbsession" id="dbsession_check" checked class="input_check" />&nbsp;
-					<label for="dbsession_check">', $txt['install_settings_dbsession_title'], '</label>
-					<br>
-					<div class="smalltext block">', $incontext['test_dbsession'] ? $txt['install_settings_dbsession_info1'] : $txt['install_settings_dbsession_info2'], '</div>
 				</td>
 			</tr>
 			<tr>


### PR DESCRIPTION
(Essentially: a setting that can default to 1, except for circumstances where we know it won't work properly, should just be set to 1 rather than asking the user to choose when almost no-one will understand what the choice means.)