### PR TITLE
Tabindex #196

### DIFF
--- a/Themes/default/scripts/register.js
+++ b/Themes/default/scripts/register.js
@@ -65,16 +65,6 @@ function smfRegister(formID, passwordDifficultyLevel, regTextStrings)
 			divHandle.style.display = '';
 	}
 
-	// A button to trigger a username search?
-	function addUsernameSearchTrigger(elementID)
-	{
-		var buttonHandle = document.getElementById(elementID);
-
-		// Attach the event to this element.
-		createEventListener(buttonHandle);
-		buttonHandle.addEventListener('click', checkUsername, false);
-	}
-
 	// This function will automatically pick up all the necessary verification fields and initialise their visual status.
 	function autoSetup(formID)
 	{
@@ -105,12 +95,6 @@ function smfRegister(formID, passwordDifficultyLevel, regTextStrings)
 				// If we're happy let's add this element!
 				if (curType)
 					addVerificationField(curType, curElement.id);
-
-				// If this is the username do we also have a button to find the user?
-				if (curType == 'username' && document.getElementById(curElement.id + '_link'))
-				{
-					addUsernameSearchTrigger(curElement.id + '_link');
-				}
 			}
 		}
 

--- a/Themes/default/templates/register_form.hbs
+++ b/Themes/default/templates/register_form.hbs
@@ -36,9 +36,7 @@
 						<dd>
 							<input type="text" name="user" id="smf_autov_username" size="30" maxlength="25" value="{{context.username}}" class="input_text">
 							<span id="smf_autov_username_div" style="display: none;">
-								<a id="smf_autov_username_link" href="#">
-									<span id="smf_autov_username_img" class="generic_icons check"></span>
-								</a>
+								<span id="smf_autov_username_img" class="generic_icons check"></span>
 							</span>
 						</dd>
 						<dt><strong><label for="smf_autov_reserve1">{{txt.user_email_address}}:</label></strong></dt>


### PR DESCRIPTION
There was a link to prompt a reload of the check-username AJAX, but in reality this wouldn't be needed as on-blur of the field did the same thing (and it's totally not clear that this is clickable to prompt a re-check anyway), so it's actually better to just remove the button and be done with it.

Fixes 196.