### PR TITLE
Don't bother trying to save a cache file if the filename is empty.

### DIFF
--- a/Sources/StoryBB/Template/Cache.php
+++ b/Sources/StoryBB/Template/Cache.php
@@ -44,7 +44,7 @@ class Cache
 	public static function push(string $cache_id, string $phpStr): bool {
 		global $cachedir;
 
-		if (!self::is_enabled())
+		if (empty($cache_id) || !self::is_enabled())
 		{
 			return false;
 		}


### PR DESCRIPTION
It's not like it can ever be loaded again. This is primarily an issue with legacy cases though.