### PR TITLE
fix: check correct setting when warning user about posts being held f…

### DIFF
--- a/Themes/default/templates/post_main.hbs
+++ b/Themes/default/templates/post_main.hbs
@@ -37,7 +37,7 @@ var icon_urls = {
 					</dd>
 				</dl>
 			</div>
-			{{#unless context.becomes_approved}}
+			{{#unless context.can_reply_approved}}
 			<p class="information">
 				<em>{{txt.wait_for_approval}}</em>
 				<input type="hidden" name="not_approved" value="1">


### PR DESCRIPTION
…or moderation (fixes #243)

Basically, changed the test in the full reply template to match the working test in the quick-reply template