### PR TITLE
Improve cron debugging

### DIFF
--- a/Themes/default/templates/error_log.hbs
+++ b/Themes/default/templates/error_log.hbs
@@ -64,7 +64,7 @@
 						<a style="display: table-cell; padding: 4px; width: 20px; vertical-align: top;" href="{{scripturl}}?action=admin;area=logs;sa=errorlog{{#if (eq ../context.sort_direction 'down')}};desc{{/if}};filter=url;value={{this.url.href}}" title="{{../txt.apply_filter}}: {{../txt.filter_only_url}}"><span class="generic_icons filter"></span></a>
 						<a style="display: table-cell;" href="{{this.url.html}}">{{this.url.html}}</a>
 					</div>
-					{{#if this.member.session}}
+					{{#if this.file}}
 						<div style="float: left; width: 100%; padding: 4px 0; line-height: 1.6em; border-top: 1px solid #e3e3e3;">
 							<a style="display: table-cell; padding: 4px; width: 20px; vertical-align: top;" href="{{scripturl}}?action=admin;area=logs;sa=errorlog{{#if (eq ../context.sort_direction 'down')}};desc{{/if}};filter=file;value={{this.file.search}}" title="{{../txt.apply_filter}}: {{../txt.filter_only_file}}"><span class="generic_icons filter"></span></a>
 							<div>

--- a/cron.php
+++ b/cron.php
@@ -160,6 +160,8 @@ function fetch_task()
 		{
 			// Update the time and go back.
 			$row['claimed_time'] = time();
+			// Also, put this into the 'session' value in case the error log needs to show it.
+			$sc = 'task' . $row['id_task'];
 			return $row;
 		}
 		else


### PR DESCRIPTION
Push the task ID into the error log, and display more debug information if it was captured as the test for determining visibility was wrong in the template.

Will help with working out what's wrong with #230