### PR TITLE
Fix compatibility with session data with some UTF-8 issues.

### DIFF
--- a/Sources/Session.php
+++ b/Sources/Session.php
@@ -59,7 +59,7 @@ function loadSession()
 		// Use database sessions?
 		if (!empty($modSettings['databaseSession_enable']))
 		{
-			@ini_set('session.serialize_handler', 'php');
+			@ini_set('session.serialize_handler', 'php_serialize');
 			session_set_save_handler('sessionOpen', 'sessionClose', 'sessionRead', 'sessionWrite', 'sessionDestroy', 'sessionGC');
 			@ini_set('session.gc_probability', '1');
 		}


### PR DESCRIPTION
When this is pulled, this might require logging out and back in again. Might be worth emptying the sessions table when updating to force that to happen.