### PR TITLE
Move a query from being run all the time everywhere.

### DIFF
--- a/Sources/Load.php
+++ b/Sources/Load.php
@@ -334,19 +334,6 @@ function reloadSettings()
 	// Define a list of allowed tags for descriptions.
 	$context['description_allowed_tags'] = array('abbr', 'anchor', 'b', 'center', 'color', 'font', 'hr', 'i', 'img', 'iurl', 'left', 'li', 'list', 'ltr', 'pre', 'right', 's', 'sub', 'sup', 'table', 'td', 'tr', 'u', 'url',);
 
-	// Get an error count, if necessary
-	if (!isset($context['num_errors']))
-	{
-		$query = $smcFunc['db_query']('', '
-			SELECT COUNT(id_error)
-			FROM {db_prefix}log_errors',
-			array()
-		);
-
-		list($context['num_errors']) = $smcFunc['db_fetch_row']($query);
-		$smcFunc['db_free_result']($query);
-	}
-
 	// Call pre load integration functions.
 	call_integration_hook('integrate_pre_load');
 }

--- a/Sources/Subs.php
+++ b/Sources/Subs.php
@@ -3892,7 +3892,7 @@ function create_button($name, $alt, $label = '', $custom = '', $force_use = fals
  */
 function setupMenuContext()
 {
-	global $context, $modSettings, $user_info, $txt, $scripturl, $sourcedir, $settings;
+	global $context, $modSettings, $user_info, $txt, $scripturl, $sourcedir, $settings, $smcFunc;
 
 	// Set up the menu privileges.
 	$context['allow_search'] = !empty($modSettings['allow_guestAccess']) ? allowedTo('search_posts') : (!$user_info['is_guest'] && allowedTo('search_posts'));
@@ -4164,10 +4164,22 @@ function setupMenuContext()
 	}
 
 	// Show how many errors there are
-	if (!empty($context['num_errors']) && allowedTo('admin_forum'))
+	if (allowedTo('admin_forum'))
 	{
-		$context['menu_buttons']['admin']['badge'] += $context['num_errors'];
-		$context['menu_buttons']['admin']['sub_buttons']['errorlog']['badge'] = $context['num_errors'];
+		$query = $smcFunc['db_query']('', '
+			SELECT COUNT(id_error)
+			FROM {db_prefix}log_errors',
+			array()
+		);
+
+		list($errors) = $smcFunc['db_fetch_row']($query);
+		$smcFunc['db_free_result']($query);
+
+		if ($errors)
+		{
+			$context['menu_buttons']['admin']['badge'] += $errors;
+			$context['menu_buttons']['admin']['sub_buttons']['errorlog']['badge'] = $errors;
+		}
 	}
 
 	// Show number of reported members


### PR DESCRIPTION
This query is only needed for displaying a badge to administrators that they have something to do. There is no way it needs to run on every single page run.