### PR TITLE
Remove the increment of error count.

### DIFF
--- a/Sources/Errors.php
+++ b/Sources/Errors.php
@@ -110,9 +110,6 @@ function log_error($error_message, $error_type = 'general', $file = null, $line 
 			array('id_error')
 		);
 		$last_error = $error_info;
-
-		// Increment our error count for the menu
-		$context['num_errors']++;
 	}
 
 	// Return the message to make things simpler.


### PR DESCRIPTION
This is partially a bug fix on the back of moving the underlying query, but also in recognition of the pointlessness of it. If the error occurs after the menu has been built (which was highly likely in the source material), this achieved nothing anyway.