### PR TITLE
Split the manage-membergroups up so there's two lists.

### DIFF
--- a/Sources/Subs-Membergroups.php
+++ b/Sources/Subs-Membergroups.php
@@ -915,11 +915,13 @@ function list_getMembergroups($start, $items_per_page, $sort, $membergroup_type)
 			mg.icons, COALESCE(gm.id_member, 0) AS can_moderate, 0 AS num_members, is_character
 		FROM {db_prefix}membergroups AS mg
 			LEFT JOIN {db_prefix}group_moderators AS gm ON (gm.id_group = mg.id_group AND gm.id_member = {int:current_member})
-		WHERE mg.min_posts {raw:min_posts}' . (allowedTo('admin_forum') ? '' : '
+		WHERE mg.min_posts {raw:min_posts}
+			AND is_character = {int:is_character}' . (allowedTo('admin_forum') ? '' : '
 			AND mg.id_group != {int:mod_group}') . '
 		ORDER BY {raw:sort}',
 		array(
 			'current_member' => $user_info['id'],
+			'is_character' => ($membergroup_type === 'character' ? 1 : 0),
 			'min_posts' => ($membergroup_type === 'post_count' ? '!= ' : '= ') . -1,
 			'mod_group' => 3,
 			'sort' => $sort,
@@ -971,7 +973,10 @@ function list_getMembergroups($start, $items_per_page, $sort, $membergroup_type)
 				)
 			);
 			while ($row = $smcFunc['db_fetch_assoc']($query))
-				$groups[$row['id_group']]['num_members'] += $row['num_members'];
+			{
+				if (isset($groups[$row['id_group']]))
+					$groups[$row['id_group']]['num_members'] += $row['num_members'];
+			}
 			$smcFunc['db_free_result']($query);
 		}
 
@@ -987,7 +992,10 @@ function list_getMembergroups($start, $items_per_page, $sort, $membergroup_type)
 				)
 			);
 			while ($row = $smcFunc['db_fetch_assoc']($query))
-				$groups[$row['id_group']]['num_members'] += $row['num_members'];
+			{
+				if (isset($groups[$row['id_group']]))
+					$groups[$row['id_group']]['num_members'] += $row['num_members'];
+			}
 			$smcFunc['db_free_result']($query);
 
 			// And collect all the characters too.
@@ -1001,7 +1009,10 @@ function list_getMembergroups($start, $items_per_page, $sort, $membergroup_type)
 				)
 			);
 			while ($row = $smcFunc['db_fetch_assoc']($query))
-				$groups[$row['main_char_group']]['num_members'] += $row['num_members'];
+			{
+				if (isset($groups[$row['main_char_group']]))
+					$groups[$row['main_char_group']]['num_members'] += $row['num_members'];
+			}
 			$smcFunc['db_free_result']($query);
 
 			if ($context['can_moderate'])

--- a/Themes/default/languages/ManageMembers.english.php
+++ b/Themes/default/languages/ManageMembers.english.php
@@ -11,9 +11,11 @@ $txt['membergroups_description'] = 'Membergroups are groups of members that have
 $txt['membergroups_modify'] = 'Modify';
 
 $txt['membergroups_add_group'] = 'Add group';
-$txt['membergroups_regular'] = 'Regular groups';
+$txt['membergroups_regular'] = 'Account groups';
+$txt['membergroups_character'] = 'Character groups';
 $txt['membergroups_post'] = 'Post count based groups';
 $txt['membergroups_guests_na'] = 'n/a';
+$txt['no_character_groups'] = 'There are no character groups configured.';
 
 $txt['membergroups_group_name'] = 'Membergroup name';
 $txt['membergroups_new_board'] = 'Visible Boards';

--- a/Themes/default/templates/membergroups_main.hbs
+++ b/Themes/default/templates/membergroups_main.hbs
@@ -1,4 +1,6 @@
 	{{! Main page listing all the groups }}
 	{{{genericlist 'regular_membergroups_list'}}}
 	<br><br>
+	{{{genericlist 'character_membergroups_list'}}}
+	<br><br>
 	{{{genericlist 'post_count_membergroups_list'}}}


### PR DESCRIPTION
This way, there's one for account groups and one for character groups. The original implementation just played adding an entry to avoid editing the theme (because icky) but this is how it should have been done really.

Fixes #419 