### PR TITLE
Fix quick reply moderation

### DIFF
--- a/Sources/Post.php
+++ b/Sources/Post.php
@@ -1580,7 +1580,7 @@ function Post2()
 	// In case we have approval permissions and want to override.
 	if (allowedTo('approve_posts') && $modSettings['postmod_active'])
 	{
-		$becomesApproved = !empty($_REQUEST['approve']) ? 1 : 0;
+		$becomesApproved = !isset($_REQUEST['approve']) || !empty($_REQUEST['approve']) ? 1 : 0;
 		$approve_has_changed = isset($row['approved']) ? $row['approved'] != $becomesApproved : false;
 	}
 


### PR DESCRIPTION
We don't communicate 'I want to approve this post' via quick reply, so checking for that doesn't work.

Fixes #594 