### PR TITLE
If we get a 5xx error while trying to reqOverlayDiv, it's trying to f…

### DIFF
--- a/Themes/default/scripts/script.js
+++ b/Themes/default/scripts/script.js
@@ -222,7 +222,11 @@ function reqOverlayDiv(desktopURL, sHeader, sIcon)
 			oPopup_body.html(help_content);
 		},
 		error: function (xhr, textStatus, errorThrown) {
-			oPopup_body.html(textStatus);
+			if (xhr.status >= 500 && xhr.status <= 599) {
+				window.location.replace(desktopURL);
+			} else {
+				oPopup_body.html(textStatus);
+			}
 		}
 	});
 	return false;


### PR DESCRIPTION
…ollow a URL so instead go to that URL.

Will suck for help items, potentially, but there aren't many in the user facing area.

Fixes #585 though, and because of the fun about to be introduced with 3rd party logins, possibly better this way.