### PR TITLE
Add 7.3 to build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.0
   - 7.2
+  - 7.3
 
 before_install:
 - sudo rm -vf /etc/apt/sources.list.d/*riak*


### PR DESCRIPTION
Note that this doesn't replace 7.2 since 7.2 specifically is coming into use on Ubuntu 18.04 LTS and similar distros as a standard version; also 7.0 is still our baseline.

Fixes #707 