### PR TITLE
Make the edit language entries page a little nicer

### DIFF
--- a/Themes/default/css/admin.css
+++ b/Themes/default/css/admin.css
@@ -666,3 +666,43 @@ h3.config_hd {
 .windowbg2.highlight2 {
 	background: #D0E7F8;
 }
+
+/* Edit language page */
+
+#editlang_desc {
+	margin-bottom: 8px;
+}
+
+.settings.editlang_entries dt {
+	width: auto;
+	font-weight: bold;
+	margin-bottom: unset;
+	float: none;
+}
+
+.settings.editlang_entries dd {
+	width: auto;
+	float: none;
+}
+
+.settings.editlang_entries dd:not(:last-child) {
+	margin-bottom: 10px;
+}
+
+.settings.editlang_entries a.main_icons::before {
+	margin-right: 4px;
+}
+
+.settings.editlang_entries dl {
+	margin-left: 1.5em;
+}
+
+.settings.editlang_entries dl dt {
+	margin-right: 10px;
+	float: left;
+}
+
+.settings.editlang_entries dl dd {
+	overflow: hidden;
+	display: block;
+}

--- a/Themes/default/css/admin.css
+++ b/Themes/default/css/admin.css
@@ -673,36 +673,27 @@ h3.config_hd {
 	margin-bottom: 8px;
 }
 
-.settings.editlang_entries dt {
-	width: auto;
+.editlang_entries dt {
 	font-weight: bold;
-	margin-bottom: unset;
-	float: none;
 }
 
-.settings.editlang_entries dd {
-	width: auto;
-	float: none;
-}
-
-.settings.editlang_entries dd:not(:last-child) {
+.editlang_entries dd:not(:last-child) {
 	margin-bottom: 10px;
 }
 
-.settings.editlang_entries a.main_icons::before {
+.editlang_entries a.main_icons::before {
 	margin-right: 4px;
 }
 
-.settings.editlang_entries dl {
+.editlang_entries dl {
 	margin-left: 1.5em;
 }
 
-.settings.editlang_entries dl dt {
+.editlang_entries dl dt {
 	margin-right: 10px;
 	float: left;
 }
 
-.settings.editlang_entries dl dd {
+.editlang_entries dl dd {
 	overflow: hidden;
-	display: block;
 }

--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -2755,10 +2755,6 @@ dl.addrules dt.floatleft {
 .generic_list_wrapper table.table_grid {
 	border-bottom: 1px solid #aaa;
 }
-
-div#editlang_desc {
-	margin-bottom: 8px;
-}
 .topic_details .smalltext {
 	font-size: 0.9em;
 }

--- a/Themes/default/templates/admin_languages_edit_entry.hbs
+++ b/Themes/default/templates/admin_languages_edit_entry.hbs
@@ -11,7 +11,7 @@
 			</div>
 
 			<div class="windowbg">
-				<dl class="settings">
+				<dl class="settings editlang_entries">
 					<dt>
 						{{context.current_entry.display}}
 					</dt>

--- a/Themes/default/templates/admin_languages_edit_entry.hbs
+++ b/Themes/default/templates/admin_languages_edit_entry.hbs
@@ -11,7 +11,7 @@
 			</div>
 
 			<div class="windowbg">
-				<dl class="settings editlang_entries">
+				<dl class="editlang_entries">
 					<dt>
 						{{context.current_entry.display}}
 					</dt>

--- a/Themes/default/templates/admin_languages_edit_list.hbs
+++ b/Themes/default/templates/admin_languages_edit_list.hbs
@@ -10,7 +10,7 @@
 		</div>
 
 		<div class="windowbg">
-			<dl class="settings editlang_entries">
+			<dl class="editlang_entries">
 {{#each context.entries}}
 				<dt>
 					<a href="{{{link}}}" class="main_icons edit">{{display}}</a>

--- a/Themes/default/templates/admin_languages_edit_list.hbs
+++ b/Themes/default/templates/admin_languages_edit_list.hbs
@@ -10,10 +10,10 @@
 		</div>
 
 		<div class="windowbg">
-			<dl class="settings">
+			<dl class="settings editlang_entries">
 {{#each context.entries}}
 				<dt>
-					<a href="{{{link}}}">{{display}}</a>
+					<a href="{{{link}}}" class="main_icons edit">{{display}}</a>
 				</dt>
 				<dd>
 	{{#if (is_array master)}}


### PR DESCRIPTION
Two columns might be nice too, with the amount of short strings.

![language-edit](https://user-images.githubusercontent.com/28991853/58842876-7927e080-8646-11e9-9b9f-6ab92881479c.png)
