### PR TITLE
Sub boards layout

### DIFF
--- a/Themes/default/css/index.css
+++ b/Themes/default/css/index.css
@@ -2911,18 +2911,19 @@ h3 .collapse {
 	margin-bottom: 3px;
 	margin-top: -1px;
 }
-/* Sub-Board tests (PH) */
-.more_sub_2 div {
-	display: inline-block;
-	width: calc(50% - 5px);
+/* Sub-boards columns */
+.children {
+	display: flex;
+	flex-wrap: wrap;
 }
-.more_sub_4 div {
-	display: inline-block;
-	width: calc(25% - 5px);
+.children.2_columns li {
+	width: 50%;
 }
-.more_sub_redirect:before,
-.more_sub_new:before {
-	content: "(PH)";
+.children.3_columns li {
+	width: 33%;
+}
+.children.4_columns li {
+	width: 25%;
 }
 /* Child boards */
 .children {

--- a/Themes/default/templates/board_main.hbs
+++ b/Themes/default/templates/board_main.hbs
@@ -87,7 +87,6 @@
 						</li>
 				{{/each}} {{! close each this.children on line 60 }}
 
-						</p><!-- ??? -->
 					</ul><!-- #board_{{this.id}}_children -->
 
 			{{/if}} {{! close if this.children on line 57 }}

--- a/Themes/default/templates/board_main.hbs
+++ b/Themes/default/templates/board_main.hbs
@@ -55,12 +55,12 @@
 
 			{{! Show the Child Boards: ". (there's a link_children but board the new ones) }}
 			{{#if this.children}}
-					<div id="board_{{this.id}}_children" class="children{{#if settings.more_sub_row}}{{else}} more_sub_4p{{/if}}">
+					<ul id="board_{{this.id}}_children" class="children {{settings.sub_boards_columns}}_columns">
 
 				{{#each this.children}}
 
 						{{! Child board has one or more new posts, bold link for child board }}
-						<div {{#if this.new}}class="strong"{{/if}}>
+						<li {{#if this.new}}class="strong"{{/if}}>
 
 					{{#if (eq this.is_redirect '1')}}
 							<span class="more_sub_redirect"></span>
@@ -84,11 +84,11 @@
 							<span><a href="{{../../../scripturl}}?action=moderate;area=postmod;sa={{#if (gt this.unapproved_topics 0)}}topics{{else}}posts{{/if}};brd={{this.id}};{{session_url}}" title="{{textTemplate ../../../txt.unapproved_posts this.unapproved_topics this.unapproved_posts}}" class="moderation_link">(!)</a></span>
 					{{/if}}
 
-						</div>
+						</li>
 				{{/each}} {{! close each this.children on line 60 }}
 
 						</p><!-- ??? -->
-					</div><!-- #board_{{this.id}}_children -->
+					</ul><!-- #board_{{this.id}}_children -->
 
 			{{/if}} {{! close if this.children on line 57 }}
 

--- a/Themes/default/theme.json
+++ b/Themes/default/theme.json
@@ -44,8 +44,14 @@
             "type": "number"
         },
         {
-            "id": "more_sub_row",
-            "label": "more_sub_row"
+            "id": "sub_boards_columns",
+            "label": "sub_boards_columns",
+            "options": {
+                "2": 2,
+                "3": 3,
+                "4": 4
+            }
+
         },
         {
             "id": "show_stats_index",

--- a/other/install_3-0_mysql.sql
+++ b/other/install_3-0_mysql.sql
@@ -736,7 +736,7 @@ VALUES (1, 'name', '{$default_theme_name}'),
   (1, 'newsfader_time', '3000'),
   (1, 'enable_news', '1'),
   (1, 'drafts_show_saved_enabled', '1'),
-  (1, 'more_sub_row', '0');
+  (1, 'sub_boards_columns', '2');
 
 INSERT INTO {$db_prefix}themes
   (id_member, id_theme, variable, value)


### PR DESCRIPTION
For #449

Using css `columns` didn't work because it will wrap long titles to the next column. And the properties that should avoid that don't seem to be supported yet. I'm not sure if there'd be another way to make them wrap similarly.

PS: I haven't tested if the settings are working because the templates caching is being a mean anti-cookie.