### PR TITLE
Move registration / settings to the top of its submenu to give it mor…

### DIFF
--- a/Sources/Admin.php
+++ b/Sources/Admin.php
@@ -241,10 +241,10 @@ function AdminMain()
 					'icon' => 'regcenter',
 					'permission' => ['admin_forum', 'moderate_forum'],
 					'subsections' => [
+						'settings' => [$txt['settings'], 'admin_forum'],
 						'register' => [$txt['admin_browse_register_new'], 'moderate_forum'],
 						'reservednames' => [$txt['admin_reserved_set'], 'admin_forum'],
 						'policies' => [$txt['admin_policies'], 'admin_forum'],
-						'settings' => [$txt['settings'], 'admin_forum'],
 					],
 				],
 				'paidsubscribe' => [


### PR DESCRIPTION
…e prominence.

The trend of 'make settings the last tab' is annoying especially when it has useful settings in it.