### PR TITLE
Add a scheduled task to prune unactivated accounts after x days.

### DIFF
--- a/Sources/ManageRegistration.php
+++ b/Sources/ManageRegistration.php
@@ -228,6 +228,7 @@ function ModifyRegistrationSettings($return_config = false)
 
 	$config_vars = array(
 			array('select', 'registration_method', array($txt['setting_registration_standard'], $txt['setting_registration_activate'], $txt['setting_registration_approval'], $txt['setting_registration_disabled'])),
+			array('int', 'remove_unapproved_accounts_days', 'min' => 0, 'max' => 30, 'subtext' => $txt['zero_to_disable']),
 			array('check', 'send_welcomeEmail'),
 			array('select', 'registration_character', array(
 				'disabled' => $txt['setting_registration_character_disabled'],

--- a/Sources/StoryBB/Model/Account.php
+++ b/Sources/StoryBB/Model/Account.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This class handles accounts.
+ *
+ * @package StoryBB (storybb.org) - A roleplayer's forum software
+ * @copyright 2018 StoryBB and individual contributors (see contributors.txt)
+ * @license 3-clause BSD (see accompanying LICENSE file)
+ *
+ * @version 3.0 Alpha 1
+ */
+
+namespace StoryBB\Model;
+
+/**
+ * This class handles accounts.
+ */
+class Account
+{
+	const ACCOUNT_NOTACTIVATED = 0;
+	const ACCOUNT_ACTIVATED = 1;
+	const ACCOUNT_NOTREACTIVATED = 2;
+	const ACCOUNT_ADMINAPPROVALPENDING = 3;
+	const ACCOUNT_DELETIONPENDING = 4;
+	const ACCOUNT_UNDERAGEPENDING = 5;
+
+	const ACCOUNT_BANNED = 10;
+}

--- a/Sources/StoryBB/Task/Schedulable/RemoveUnapprovedAccounts.php
+++ b/Sources/StoryBB/Task/Schedulable/RemoveUnapprovedAccounts.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Check for and remove accounts that haven't validated.
+ *
+ * @package StoryBB (storybb.org) - A roleplayer's forum software
+ * @copyright 2018 StoryBB and individual contributors (see contributors.txt)
+ * @license 3-clause BSD (see accompanying LICENSE file)
+ *
+ * @version 3.0 Alpha 1
+ */
+
+namespace StoryBB\Task\Schedulable;
+
+use StoryBB\Model\Account;
+
+/**
+ * Check for and remove move topic notices that have expired.
+ */
+class RemoveUnapprovedAccounts extends \StoryBB\Task\Schedulable
+{
+	/**
+	 * Check for and remove unapproved accounts that haven't approved after a while.
+	 * @return bool True on success
+	 */
+	public function execute(): bool
+	{
+		global $smcFunc, $modSettings;
+
+		if (empty($modSettings['remove_unapproved_accounts_days']))
+		{
+			return true;
+		}
+
+		$date_registered = time() - ((int) $modSettings['remove_unapproved_accounts_days'] * 86400);
+
+		$smcFunc['db_query']('', '
+			DELETE FROM {db_prefix}members
+			WHERE is_activated IN ({int:unactivated}, {int:unactivatedbanned})
+			AND date_registered <= {int:date_registered}',
+			[
+				'unactivated' => Account::ACCOUNT_NOTACTIVATED,
+				'unactivatedbanned' => Account::ACCOUNT_BANNED + Account::ACCOUNT_NOTACTIVATED,
+			]
+		);
+
+		return true;
+	}
+}

--- a/Themes/default/languages/en-us/Login.php
+++ b/Themes/default/languages/en-us/Login.php
@@ -81,6 +81,7 @@ $txt['setting_registration_disabled'] = 'Registration Disabled';
 $txt['setting_registration_standard'] = 'Immediate Registration';
 $txt['setting_registration_activate'] = 'Email Activation';
 $txt['setting_registration_approval'] = 'Admin Approval';
+$txt['setting_remove_unapproved_accounts_days'] = 'Remove unapproved accounts after how many days?';
 $txt['setting_send_welcomeEmail'] = 'Send welcome email to new members';
 $txt['setting_show_cookie_notice'] = 'Show a cookie notice in the footer to guests';
 

--- a/Themes/default/languages/en-us/ManageScheduledTasks.php
+++ b/Themes/default/languages/en-us/ManageScheduledTasks.php
@@ -49,6 +49,8 @@ $txt['scheduled_task_clean_exports'] = 'Clean data exports';
 $txt['scheduled_task_desc_clean_exports'] = 'Removes archived data exports once they expire. Should not be disabled.';
 $txt['scheduled_task_scrub_logs'] = 'Scrub logs for privacy';
 $txt['scheduled_task_desc_scrub_logs'] = 'Removes privacy-related data from logs. Should not be disabled.';
+$txt['scheduled_task_remove_unapproved_accts'] = 'Remove unapproved accounts';
+$txt['scheduled_task_desc_remove_unapproved_accts'] = 'Removed accounts that have not been approved. Should not be disabled.';
 
 $txt['scheduled_task_reg_starting'] = 'Starting at %1$s';
 $txt['scheduled_task_reg_repeating'] = 'repeating every %1$d %2$s';

--- a/other/install_3-0_mysql.sql
+++ b/other/install_3-0_mysql.sql
@@ -517,7 +517,8 @@ VALUES
   (12, 0, 180, 1, 'd', 0, 'remove_topic_redirect', 'StoryBB\\Task\\Schedulable\\RemoveTopicRedirects'),
   (13, 0, 240, 1, 'd', 0, 'remove_old_drafts', 'StoryBB\\Task\\Schedulable\\RemoveOldDrafts'),
   (14, 0, 300, 1, 'd', 0, 'clean_exports', 'StoryBB\\Task\\Schedulable\\CleanExports'),
-  (15, 0, 360, 1, 'd', 0, 'scrub_logs', 'StoryBB\\Task\\Schedulable\\ScrubLogs');
+  (15, 0, 360, 1, 'd', 0, 'scrub_logs', 'StoryBB\\Task\\Schedulable\\ScrubLogs'),
+  (16, 0, 420, 1, 'd', 0, 'remove_unapproved_accts', 'StoryBB\\Task\\Schedulable\\RemoveUnapprovedAccounts');
 
 # --------------------------------------------------------
 
@@ -577,6 +578,7 @@ VALUES ('sbbVersion', '{$sbb_version}'),
   ('xmlnews_enable', '1'),
   ('xmlnews_maxlen', '255'),
   ('registration_method', '{$registration_method}'),
+  ('remove_unapproved_accounts_days', '7'),
   ('send_validation_onChange', '0'),
   ('send_welcomeEmail', '1'),
   ('allow_editDisplayName', '1'),


### PR DESCRIPTION
Note that this doesn't touch admin approvals, or people who changed their email and need to revalidate.

Fixes #774 