### PR TITLE
Don't restrict membergroup badge count to > 1 when there is no badge.

### DIFF
--- a/Themes/natural/scripts/icondropdown.js
+++ b/Themes/natural/scripts/icondropdown.js
@@ -8,7 +8,10 @@ function refreshIconPreview()
 {
 	if (!$('#membergroup_has_badge').prop('checked')) {
 		$('#badge_config').hide();
+		$('#icon_count_input').attr('min', 0);
 		return;
+	} else {
+		$('#icon_count_input').attr('min', 1);
 	}
 
 	$('#badge_config').show();


### PR DESCRIPTION
Fix #890 